### PR TITLE
cabecera y ejemplos para uso de consola multiplataforma

### DIFF
--- a/Fundamentos de la Programacion/colores/colores.h
+++ b/Fundamentos de la Programacion/colores/colores.h
@@ -1,0 +1,114 @@
+/**
+ * Esta libreria permite colorear la salida tanto bajo windows como bajo linux
+ * 
+ * Uso: 
+ *   - debe estar incluida en el proyecto
+ *   - debe haber un #include "colores.h" al comienzo del fichero
+ *   - llama a setColor(color) para cambiar el color actual
+ *      usa las constantes Gris, Rojo, Verde, Azul para simplificarte la vida!
+ *   - llama a cout << algo para mostrar 'algo' en ese color
+ * 
+ * Autor: manuel.freire@fdi.ucm.es
+ * Licencia: https://creativecommons.org/licenses/by-sa/3.0/
+ */
+
+#ifndef COLORES_H_
+#define COLORES_H_
+
+// Alias de colores validos; sientete libre de ampliar la lista. Para cada nuevo color,
+//  - version windows, a colocar en el "switch" de la definicion de setColor para windows: 
+//    https://docs.microsoft.com/en-us/windows/console/console-screen-buffers#_win32_character_attributes
+//  - version linux, a colocar en el "switch" de setColor para linux:
+//    http://bluesock.org/~willkg/dev/ansi.html (o equivalente) 
+enum Color {
+    Gris, 
+    Rojo, 
+    Verde, 
+    Azul, 
+    Blanco=15
+};
+
+#ifdef _WIN32_
+// este codigo solo se ejecuta bajo Windows -->
+
+    #include <windows.h>
+    #include <conio.h>
+
+	// implementacion de setColor bajo Windows, con SetConsoleTextAttribute
+    void setColor(int color) {
+        WORD a = 0;
+        switch (color) {
+            case Gris: a = FOREGROUND_RED|FOREGROUND_BLUE|FOREGROUND_GREEN; break;
+            case Rojo: a = FOREGROUND_RED|FOREGROUND_INTENSITY; break;
+            case Verde: a = FOREGROUND_GREEN|FOREGROUND_INTENSITY; break;
+            case Azul: a = FOREGROUND_BLUE|FOREGROUND_INTENSITY; break;
+            default: a = color;
+        }
+        SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), a);
+    }
+
+// <-- fin de codigo windows-exclusivo
+#elif __linux__ 
+// este codigo solo se ejecuta bajo linux -->
+
+    #include <iostream>
+    #include <sstream>
+    #include <cstdio>
+    #include <termios.h>
+    #include <unistd.h>
+    
+    namespace Colores {
+        
+        // constantes globales para colores; sientete libre de ampliarlas
+        // ver http://bluesock.org/~willkg/dev/ansi.html o cualquier referencia ANSI
+        const char *ANSI_COLOR_RED   =  "\x1b[31;1m";
+        const char *ANSI_COLOR_GREEN =  "\x1b[32;1m";
+        const char *ANSI_COLOR_YELLOW = "\x1b[33;1m";
+        const char *ANSI_COLOR_BLUE =   "\x1b[34;1m";
+        const char *ANSI_COLOR_MAGENTA ="\x1b[35;1m";
+        const char *ANSI_COLOR_CYAN  =  "\x1b[36;1m";
+        const char *ANSI_COLOR_WHITE  = "\x1b[37;1m";
+        const char *ANSI_COLOR_RESET  = "\x1b[0m";
+        const char *ANSI_COLOR_BLUE_BG = "\x1b[44m";
+        const char *ANSI_COLOR_GREEN_BG = "\x1b[42m";
+        const char *ANSI_WHITE_ON_REDG = "\x1b[37;41m";
+        const char *ANSI_WHITE_ON_YELLOW = "\x1b[37;43m";
+        const char *ANSI_WHITE_ON_BLACK = "\x1b[37;40m";
+        const char *ANSI_CLS = "\x1b[2J";          
+    }
+    
+    // cambio de color bajo linux
+    void setColor(int color) {
+        const char *a = Colores::ANSI_COLOR_RESET;
+        switch (color) {
+            case Gris: a = Colores::ANSI_COLOR_RESET; break;
+            case Rojo: a = Colores::ANSI_COLOR_RED; break;
+            case Verde: a = Colores::ANSI_COLOR_GREEN; break;
+            case Azul: a = Colores::ANSI_COLOR_BLUE; break;
+            case 15: a = Colores::ANSI_COLOR_WHITE; break;
+            default: a = Colores::ANSI_COLOR_RESET;
+        }
+        std::cout << a;
+    }    
+    
+    // emula getch() de conio.h
+    int getch() {
+        // from http://stackoverflow.com/a/23035044/15472
+        struct termios oldattr, newattr;
+        int ch;
+        tcgetattr( STDIN_FILENO, &oldattr );
+        newattr = oldattr;
+        newattr.c_lflag &= ~( ICANON | ECHO );
+        tcsetattr( STDIN_FILENO, TCSANOW, &newattr );
+        ch = getchar();
+        tcsetattr( STDIN_FILENO, TCSANOW, &oldattr );
+        return ch;
+    }
+        
+// <-- fin de codigo linux-exclusivo
+#else         
+    #error Platform not supported
+#endif
+
+// <-- fin de ifndef COLORES_H_ inicial
+#endif 

--- a/Fundamentos de la Programacion/colores/consola_avanzada_multiplataforma.md
+++ b/Fundamentos de la Programacion/colores/consola_avanzada_multiplataforma.md
@@ -1,0 +1,30 @@
+<!--
+Esta obra está bajo una licencia Licencia Creative Commons Atribución 4.0 Internacional. 
+Licencia: http://creativecommons.org/licenses/by/4.0/
+-->
+
+# Manejo de terminal avanzado bajo linux en prácticas de FP
+
+Esta carpeta contiene código para ayudarte a escribir prácticas de FP bajo linux que usan 
+
+* colores en la terminal. Bajo Windows, esta funcionalidad se consigue mediante llamadas a `windows.h`, pero esta cabecera no está disponible, por motivos obvios, bajo Linux.
+
+* lectura de teclas (sin necesidad de pulsar enter) desde la terminal. Bajo windows, conio.h soporta un `getch()` que sí permite esta funcionalidad. Bajo linux, la terminal está configurada para no enviar eventos a los programas hasta que se pulsa "enter"; así que hay que redefinir ´getch()´ para evitar este efecto.
+
+# Uso 
+
+Incluye `colores.h` en tu proyecto, y *no* incluyas `windows.h` (que no compilaría bajo linux) ni `conio.h` (ya que daría conflicto bajo linux con la versión incluida en `colores.h`).
+
+Usa `setColor()` en lugar de `SetConsoleTextAttribute()` para modificar el color, limpiar la pantalla, y en general modificar la consola.
+
+Usa `getch()`, tanto en linux como en windows, para capturar tecla a tecla.
+
+Juega con los ejemplos de test.cpp y test2.cpp para ver más detalles de uso. 
+
+# Uso en prácticas
+
+Habla con tu profesor para saber si está dispuesto a corregir tus prácticas bajo linux. Si las va a corregir bajo windows, asegúrate de que el comportamiento es idéntico en ambas plataformas (es decir, pruébala bajo windows) antes de entregarla: el autor de este código no se responsabiliza de cualquier problema de compatibilidad.
+
+# Otras recomendaciones
+
+Nunca uses `system("pause");` en tu código. El uso de `system()` hace que tu código deje inmediatamente de ser multiplataforma. 

--- a/Fundamentos de la Programacion/colores/test.cpp
+++ b/Fundamentos de la Programacion/colores/test.cpp
@@ -1,0 +1,30 @@
+/**
+ * Un ejemplo de uso de colores.h multiplataforma:
+ * deberia funcionar igual en linux y en windows.
+ *
+ * Usa setColor en lugar de SetConsoleTextAttribute ó escapes llamados directamente
+ * Usa getch implementado vía getchar-en-consola-en-modo-raw para capturar teclas
+ */
+
+#include <iostream>
+#include "colores.h"
+
+using namespace std;
+
+int main() {
+        
+    cout << "yo estoy en color normal\n";
+    setColor(Rojo);
+    cout << "yo aparezco en color rojo\n";
+    setColor(Azul);
+    cout << "yo voy de azul\n";
+    setColor(15);
+    cout << "yo voy de intenso\n";
+    setColor(Gris);
+    cout << "yo estoy en color normal\n";
+    
+    cout << "pulsa una tecla ... ";
+    cout << "has pulsado '" << (char)getch() << "' !\n";
+    
+    return 0;    
+}

--- a/Fundamentos de la Programacion/colores/test2.cpp
+++ b/Fundamentos de la Programacion/colores/test2.cpp
@@ -1,0 +1,29 @@
+/**
+ * Un ejemplo de uso de colores.h que solamente funciona en consolas ANSI
+ * (como la de linux). En este caso, no se usan llamadas a setColor. 
+ */
+
+#include <iostream>
+#include "colores.h"
+
+using namespace std;
+
+int main() {
+
+    // limpio pantalla
+    cout << Colores::ANSI_CLS;    
+    cout << "yo estoy en color normal\n";
+    cout << Colores::ANSI_COLOR_BLUE_BG;
+    cout << "fondo azul ahora\n";
+    cout << "y hasta que lo cambie\n";
+    cout << Colores::ANSI_COLOR_GREEN_BG;
+    cout << "esto\n";
+    cout << Colores::ANSI_WHITE_ON_YELLOW;
+    cout << "es\n";
+    cout << Colores::ANSI_WHITE_ON_REDG;
+    cout << "una\n";
+    cout << Colores::ANSI_COLOR_RESET; 
+    cout << "prueba\n";
+        
+    return 0;    
+}


### PR DESCRIPTION
Es frecuente hacer prácticas de FP en las que se pide usar funcionalidad de `windows.h` para controlar colores, o de conio.h para usar `getch()` (que bajo linux, por defecto, usa un buffer que sólo retorna al programa cuando se pulsa enter). Valga como ejemplo la práctica del Sokoban del curso 2016-17 de FP de los grados. Escribir prácticas bajo linux que hagan uso de esta funcionalidad es complicado; y conseguir que el profesor luego las corrija en linux también podía serlo.

Este PR contiene una cabecera, `colores.h`, que permite escribir código multiplataforma (debería funcionar igual en linux y windows) con ambas funcionalidades: colores y getch-sin-buffer. 